### PR TITLE
Add package.json for NPM publishing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -127,6 +127,9 @@ Internally theres a bit of metaprogramming soup to make it easier to define colo
 # Changes
 
 <dl>  
+  <dt><em>May 12, 2015</em></dt>
+  <dd>Version 1.0.2: Add package.json for NPM publishing.</dd>
+
   <dt><em>May 3, 2013</em></dt>
   <dd>Version 1.0.1: Bug fix for alpha support in achromatic HSV to RGB.</dd>
   

--- a/color.js
+++ b/color.js
@@ -834,7 +834,6 @@ if (!net.brehaut) { net.brehaut = {}; }
 
 /* Export to CommonJS
 */
-var module;
-if(module) {
-  module.exports.Color = net.brehaut.Color;
+if(typeof module !== 'undefined') {
+  module.exports = net.brehaut.Color;
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "color-js",
+  "version": "1.0.2",
+  "description": "A color management API for JavaScript",
+  "main": "color.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "node ./test/color-test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/brehaut/color-js.git"
+  },
+  "keywords": [
+    "color",
+    "immutable"
+  ],
+  "author": "Andrew Brehaut <andrew@brehaut.net> (https://brehaut.net/)",
+  "contributors": [
+    "Tim Baumann <tim@timbaumann.info> (http://timbaumann.info)",
+    "Matt Wilson (http://problemattic.net)",
+    "Simon Heimler",
+    "Michel Vielmetter",
+    "Jim O'Brien <git@jimmed.net>"
+  ],
+  "license": "BSD 2-Clause",
+  "bugs": {
+    "url": "https://github.com/brehaut/color-js/issues"
+  },
+  "homepage": "https://github.com/brehaut/color-js#readme",
+  "devDependencies": {
+    "vows": "^0.8.1"
+  }
+}

--- a/test/color-test.js
+++ b/test/color-test.js
@@ -1,8 +1,6 @@
 var vows   = require('vows'),
     assert = require('assert'),
-    color  = require('../color');
-
-var Color = color.Color;
+    Color  = require('../color');
 
 assert.colorEqual = function(color1, color2) {
   assert.deepEqual(color1.toRGB(), color2.toRGB());


### PR DESCRIPTION
As per #12 I've done everything that's required to ready this module for NPM.

It should be as simple as running:

```
npm publish
```

Please double-check that the license/author/contributors are all correct.

**N.B.** I have changed the CommonJS output so that it returns `Color` as a default export, rather than a named one. This is convention for a library providing a single export.

For what it's worth, if this isn't merged within a week I will gladly publish this under my own username (with the proper mentions back to you).
