### PR TITLE
Added namespace to support typescript 3+ imports

### DIFF
--- a/color.d.ts
+++ b/color.d.ts
@@ -117,6 +117,7 @@ declare module net.brehaut {
     // public constructor
     function Color(): Color;
     function Color(color: ColorConstructorValue): Color;
+    namespace Color{}
 }
 
 export = net.brehaut.Color;


### PR DESCRIPTION
From typescript 3 importing the library as:
`import * as Color from 'color-js';`
is not allowed.

Following the issue [https://github.com/Microsoft/TypeScript/issues/5073](https://github.com/Microsoft/TypeScript/issues/5073) I fixed the color.d.ts file adding the namespace.